### PR TITLE
Update fix_for_opt_buildbreak.patch

### DIFF
--- a/releases/10.0.0/patches_external/fix_for_opt_buildbreak.patch
+++ b/releases/10.0.0/patches_external/fix_for_opt_buildbreak.patch
@@ -7,6 +7,6 @@
    Core
    Coroutines
 +  Demangle
+   Extensions
    IPO
    IRReader
-   InstCombine


### PR DESCRIPTION
see https://github.com/llvm/llvm-project/blob/release/10.x/llvm/tools/opt/CMakeLists.txt

this PR resolves

```
-- [LLVM_PATCHER] : Apply /llvm_patches/releases/10.0.0/patches_external/fix_for_opt_buildbreak.patch file
patching file tools/opt/CMakeLists.txt
Hunk #1 FAILED at 9.
1 out of 1 hunk FAILED -- saving rejects to file tools/opt/CMakeLists.txt.rej
CMake Error at /llvm_patches/CMakeLists.txt:245 (message):
  [LLVM_PATCHER] : error: applying patch
  '/llvm_patches/releases/10.0.0/patches_external/fix_for_opt_buildbreak.patch'
  failed
```